### PR TITLE
邮件模块的部分重构以及邮件发送器服务模块的编写

### DIFF
--- a/src/main/java/com/example/jesse/item_market/email/dto/EmailContent.java
+++ b/src/main/java/com/example/jesse/item_market/email/dto/EmailContent.java
@@ -6,37 +6,58 @@ import lombok.*;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 
-import java.nio.file.Path;
 import java.time.Duration;
 
 import static java.lang.String.format;
 
 /**
  * 向指定用户发送邮件的内容实体。
- *（支持 Jacson 的序列化与反序列化）
+ *（支持 Jackson 的序列化与反序列化）
  */
 @Data
 @ToString
+@EqualsAndHashCode
 @JsonTypeInfo(
     use      = JsonTypeInfo.Id.CLASS,        // 使用完全限定类名作为类型标识
     include  = JsonTypeInfo.As.PROPERTY,     // 作为单独属性包含
     property = "@class"                      // 类型信息的属性名
 )
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access  = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class EmailContent
 {
     /** 发给谁 (如 PerterGriffen@gmail.com) */
     private String to;
 
-    /** 邮箱主题 */
+    /** 邮件主题 */
     private String subject;
 
     /** 邮件正文 */
     private String textBody;
 
-    /** 附件路径（可以为 null 表示没有附件）*/
+    /** 附件文件名（可以为 null 表示没有附件）*/
     @Nullable
-    private String attachmentPath;
+    private String attachmentName;
+
+    /** 附件数据（可以为 null 表示没有附件）*/
+    @Nullable
+    private byte[] attachmentData;
+
+    /**
+     * 检查这封邮件是否包含附件。
+     *
+     * <ul>
+     *     <li>true  包含附件</li>
+     *     <li>false 不包含附件</li>
+     * </ul>
+     */
+    public boolean hasAttachment()
+    {
+        return
+        this.attachmentName != null &&
+        this.attachmentData != null &&
+        this.attachmentData.length > 0;
+    }
 
     /**
      * 发送验证码邮件需要的内容。
@@ -69,7 +90,36 @@ public class EmailContent
             );
 
             // 验证码邮件不需要附件内容
-            emailContent.setAttachmentPath(null);
+            emailContent.setAttachmentName(null);
+            emailContent.setAttachmentData(null);
+
+            return emailContent;
+        });
+    }
+
+    /**
+     * 发送纯文本邮件的内容。
+     *
+     * @param userEmail     收件人邮箱
+     * @param subject       邮件标题
+     * @param message       邮件正文
+     *
+     * @return 发布纯文本邮件的 {@link Mono}
+     */
+    public static @NotNull Mono<EmailContent>
+    fromJustText(String userEmail, String subject, String message)
+    {
+        return
+        Mono.fromCallable(() -> {
+            EmailContent emailContent = new EmailContent();
+
+            emailContent.setTo(userEmail);
+            emailContent.setSubject(subject);
+            emailContent.setTextBody(message);
+
+            // 纯文本邮件没有附件内容
+            emailContent.setAttachmentName(null);
+            emailContent.setAttachmentData(null);
 
             return emailContent;
         });
@@ -78,18 +128,20 @@ public class EmailContent
     /**
      * 发送带附件的邮件所需要的内容。
      *
-     * @param userName   收件人姓名
-     * @param userEmail  收件人邮箱
-     * @param subject    邮件标题（按 “用户：XXX” 开头）
-     * @param message    邮件正文
-     * @param attachment 附件路径
+     * @param userName       收件人姓名
+     * @param userEmail      收件人邮箱
+     * @param subject        邮件标题（按 “用户：XXX” 开头）
+     * @param message        邮件正文
+     * @param attachmentName 附件文件名
+     * @param attachmentData 附件完整数据
      *
      * @return 发布带附件的邮件内容的 Mono
      */
     public static @NotNull Mono<EmailContent>
     formWithAttachment(
         String userName, String userEmail,
-        String subject, String message, String attachment)
+        String subject, String message,
+        String attachmentName, byte[] attachmentData)
     {
         return
         Mono.fromCallable(() -> {
@@ -98,11 +150,8 @@ public class EmailContent
             emailContent.setTo(userEmail);
             emailContent.setSubject("用户：" + userName + " " + subject);
             emailContent.setTextBody(message);
-
-            Path attachmentPath
-                = Path.of(attachment).normalize();
-
-            emailContent.setAttachmentPath(attachmentPath.toString());
+            emailContent.setAttachmentName(attachmentName);
+            emailContent.setAttachmentData(attachmentData);
 
             return emailContent;
         });

--- a/src/main/java/com/example/jesse/item_market/email/utils/MimeTypeGetter.java
+++ b/src/main/java/com/example/jesse/item_market/email/utils/MimeTypeGetter.java
@@ -1,0 +1,58 @@
+package com.example.jesse.item_market.email.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Mine type 获取器。*/
+public class MimeTypeGetter
+{
+    /** 默认的二进制流类型。*/
+    private final static
+    String DEFAULT_MIME_TYPE = "application/octet-stream";
+
+    /** 常用的 Mine Type 映射表。*/
+    private static final
+    Map<String, String> MIME_TYPES = new HashMap<>();
+
+    /* 在这个工具类构建时填入常用的 Mine Type 映射。*/
+    static {
+        MIME_TYPES.put("pdf", "application/pdf");
+        MIME_TYPES.put("doc", "application/msword");
+        MIME_TYPES.put("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        MIME_TYPES.put("xls", "application/vnd.ms-excel");
+        MIME_TYPES.put("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        MIME_TYPES.put("ppt", "application/vnd.ms-powerpoint");
+        MIME_TYPES.put("pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation");
+        MIME_TYPES.put("jpg", "image/jpeg");
+        MIME_TYPES.put("jpeg", "image/jpeg");
+        MIME_TYPES.put("png", "image/png");
+        MIME_TYPES.put("gif", "image/gif");
+        MIME_TYPES.put("txt", "text/plain");
+        MIME_TYPES.put("html", "text/html");
+        MIME_TYPES.put("xml", "application/xml");
+        MIME_TYPES.put("zip", "application/zip");
+    }
+
+    /** 通过文件名后缀尝试映射对应的 Mine Type。*/
+    public static String
+    getMimeTypeFromExtention(String fileName)
+    {
+        if (fileName == null || fileName.trim().isEmpty()) {
+            return DEFAULT_MIME_TYPE;
+        }
+
+        int dotIndex = fileName.lastIndexOf(".");
+
+        if (dotIndex > 0)
+        {
+            String extention
+                = fileName.substring(dotIndex + 1)
+                          .toLowerCase();
+
+            return
+            MIME_TYPES.getOrDefault(extention, DEFAULT_MIME_TYPE);
+        }
+
+        return DEFAULT_MIME_TYPE;
+    }
+}

--- a/src/main/java/com/example/jesse/item_market/email_send_task/EmailSenderTask.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/EmailSenderTask.java
@@ -1,7 +1,7 @@
 package com.example.jesse.item_market.email_send_task;
 
 import com.example.jesse.item_market.email.dto.EmailContent;
-import com.example.jesse.item_market.email_send_task.dto.TaskPriority;
+import com.example.jesse.item_market.email_send_task.impl.TaskPriority;
 import org.springframework.data.redis.serializer.SerializationException;
 import reactor.core.publisher.Mono;
 
@@ -35,4 +35,7 @@ public interface EmailSenderTask
 
     /** 关闭优先有序集合的邮件发送任务。*/
     void stopExcuteEmailSenderTask();
+
+    /** 检查邮件任务是否已经启动。*/
+    boolean isTaskStarted();
 }

--- a/src/main/java/com/example/jesse/item_market/email_send_task/dto/AttachmentMailArgsDTO.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/dto/AttachmentMailArgsDTO.java
@@ -1,0 +1,30 @@
+package com.example.jesse.item_market.email_send_task.dto;
+
+import lombok.*;
+
+/** 携带附件的邮件构造参数 DTO。*/
+@Data
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class AttachmentMailArgsDTO
+{
+    /** 收件人姓名 */
+    public String userName;
+
+    /** 收件人邮箱 */
+    public String userEmail;
+
+    /** 邮件标题（按 “用户：XXX” 开头） */
+    public String subject;
+
+    /** 邮件正文 */
+    public String message;
+
+    /** 附件文件名 */
+    String attachmentName;
+
+    /** 附件完整数据 */
+    byte[] attachmentData;
+}

--- a/src/main/java/com/example/jesse/item_market/email_send_task/dto/EmailContentDTO.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/dto/EmailContentDTO.java
@@ -1,0 +1,38 @@
+package com.example.jesse.item_market.email_send_task.dto;
+
+import com.example.jesse.item_market.email.dto.EmailContent;
+import jakarta.annotation.Nullable;
+import lombok.*;
+
+/** 通用发送邮件内容，用于前端的 JSON 序列化 / 反序列化。*/
+@Data
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor(access  = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class EmailContentDTO
+{
+    /** 发给谁 (如 PerterGriffen@gmail.com) */
+    private String to;
+
+    /** 邮件主题 */
+    private String subject;
+
+    /** 邮件正文 */
+    private String textBody;
+
+    /** 附件文件名（可以为 null 表示没有附件）*/
+    @Nullable
+    private String attachmentName;
+
+    /** 附件数据（可以为 null 表示没有附件）*/
+    @Nullable
+    private byte[] attachmentData;
+
+    /** 转换成 {@link EmailContent} 类型。*/
+    public EmailContent toEmailContent()
+    {
+        return new
+        EmailContent(to, subject, textBody, attachmentName, attachmentData);
+    }
+}

--- a/src/main/java/com/example/jesse/item_market/email_send_task/dto/EmailTaskDTO.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/dto/EmailTaskDTO.java
@@ -1,6 +1,7 @@
 package com.example.jesse.item_market.email_send_task.dto;
 
 import com.example.jesse.item_market.email.dto.EmailContent;
+import com.example.jesse.item_market.email_send_task.impl.TaskPriority;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/example/jesse/item_market/email_send_task/dto/TextMailArgsDTO.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/dto/TextMailArgsDTO.java
@@ -1,0 +1,21 @@
+package com.example.jesse.item_market.email_send_task.dto;
+
+import lombok.*;
+
+/** 纯文本邮件构造参数 DTO。*/
+@Data
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor(access  = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class TextMailArgsDTO
+{
+    /** 收件人邮箱 */
+    private String userEmail;
+
+    /** 邮件标题 */
+    private String subject;
+
+    /** 邮件正文 */
+    private String message;
+}

--- a/src/main/java/com/example/jesse/item_market/email_send_task/dto/VerifyMailArgsDTO.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/dto/VerifyMailArgsDTO.java
@@ -1,0 +1,21 @@
+package com.example.jesse.item_market.email_send_task.dto;
+
+import lombok.*;
+
+/** 验证码邮件构造参数 DTO。*/
+@Data
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor(access  = AccessLevel.PUBLIC)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class VerifyMailArgsDTO
+{
+    /** 收件人姓名 */
+    private String userName;
+
+    /** 收件人邮箱 */
+    private String userEmail;
+
+    /** 验证码有效期 */
+    private Long expired;
+}

--- a/src/main/java/com/example/jesse/item_market/email_send_task/impl/TaskPriority.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/impl/TaskPriority.java
@@ -1,4 +1,4 @@
-package com.example.jesse.item_market.email_send_task.dto;
+package com.example.jesse.item_market.email_send_task.impl;
 
 import lombok.Getter;
 

--- a/src/main/java/com/example/jesse/item_market/email_send_task/impl/TaskType.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/impl/TaskType.java
@@ -1,4 +1,4 @@
-package com.example.jesse.item_market.email_send_task.dto;
+package com.example.jesse.item_market.email_send_task.impl;
 
 import lombok.Getter;
 

--- a/src/main/java/com/example/jesse/item_market/email_send_task/route/EmailTaskRouteConfig.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/route/EmailTaskRouteConfig.java
@@ -1,0 +1,39 @@
+package com.example.jesse.item_market.email_send_task.route;
+
+import com.example.jesse.item_market.email_send_task.service.EmailTaskService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static com.example.jesse.item_market.email_send_task.route.EmailTaskURI.*;
+
+/** 邮件任务执行服务路由函数配置类。*/
+@Slf4j
+@Configuration
+public class EmailTaskRouteConfig
+{
+    @Autowired
+    private EmailTaskService emailTaskService;
+
+    @Bean
+    public RouterFunction<ServerResponse>
+    emailTaskRouteFunction()
+    {
+        return
+        RouterFunctions
+            .route()
+            .PUT(START_EMAIL_TASK_URI,       this.emailTaskService::startEmailTask)
+            .PUT(STOP_EMAIL_TASK_URI,        this.emailTaskService::stopEmailTask)
+            .PUT(STOP_POLL_DELAY_ZSET_URI,   this.emailTaskService::stopPollDelayZset)
+            .PUT(STOP_EMAIL_SENDER_TASK_URI, this.emailTaskService::stopExecuteEmailSenderTask)
+            .POST(ADD_EMAIL_TASK_URI,        this.emailTaskService::addEmailTask)
+            .POST(ADD_VERIFY_CODE_EMAIL_TASK_URI, this.emailTaskService::addVerifyCodeEmailTask)
+            .POST(ADD_TEXT_EMAIL_TASK_URI,       this.emailTaskService::addTextEmailTask)
+            .POST(ADD_ATTACHMENT_EMAIL_TASK_URI, this.emailTaskService::addAttechmentEmailTask)
+            .build();
+    }
+}

--- a/src/main/java/com/example/jesse/item_market/email_send_task/route/EmailTaskURI.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/route/EmailTaskURI.java
@@ -1,0 +1,44 @@
+package com.example.jesse.item_market.email_send_task.route;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/** 邮件任务服务 URI 配置类。*/
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final public class EmailTaskURI
+{
+    /** 邮件任务根 URI */
+    private static final String
+    EMAIL_TASK_ROOT_URI = "/api/email-task";
+
+    /** 启动 项目邮件任务 URI */
+    public static final String
+    START_EMAIL_TASK_URI = EMAIL_TASK_ROOT_URI + "/start";
+
+    /** 停止 项目邮件任务 URI */
+    public static final String
+    STOP_EMAIL_TASK_URI = EMAIL_TASK_ROOT_URI + "/stop";
+
+    /** 停止 延迟邮件任务有序集合的轮询 URI */
+    public static final String
+    STOP_POLL_DELAY_ZSET_URI = EMAIL_TASK_ROOT_URI + "/stop-poll-delay-zset";
+
+    /** 停止 优先有序集合的邮件发送任务 URI */
+    public static final String
+    STOP_EMAIL_SENDER_TASK_URI = EMAIL_TASK_ROOT_URI + "/stop-email-send";
+
+    /** 添加一个新的通用邮件任务 URI */
+    public static final String
+    ADD_EMAIL_TASK_URI = EMAIL_TASK_ROOT_URI + "/add-email-task";
+
+    /** 添加一个新的验证码邮件任务 URI */
+    public static final String
+    ADD_VERIFY_CODE_EMAIL_TASK_URI = EMAIL_TASK_ROOT_URI + "/add-verify-email-task";
+
+    /** 添加一个新的纯文本邮件任务 URI */
+    public static final String
+    ADD_TEXT_EMAIL_TASK_URI = EMAIL_TASK_ROOT_URI + "/add-text-email-task";
+
+    public static final String
+    ADD_ATTACHMENT_EMAIL_TASK_URI = EMAIL_TASK_ROOT_URI + "/add-attachment-email-task";
+}

--- a/src/main/java/com/example/jesse/item_market/email_send_task/service/EmailTaskService.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/service/EmailTaskService.java
@@ -1,0 +1,41 @@
+package com.example.jesse.item_market.email_send_task.service;
+
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+/** 邮件任务服务接口。*/
+public interface EmailTaskService
+{
+    /** 启动 项目邮件任务。*/
+    Mono<ServerResponse>
+    startEmailTask(ServerRequest request);
+
+    /** 停止 项目邮件任务。*/
+    Mono<ServerResponse>
+    stopEmailTask(ServerRequest request);
+
+    /** 停止 延迟邮件任务有序集合的轮询。*/
+    Mono<ServerResponse>
+    stopPollDelayZset(ServerRequest request);
+
+    /** 停止 优先有序集合的邮件发送任务。*/
+    Mono<ServerResponse>
+    stopExecuteEmailSenderTask(ServerRequest request);
+
+    /** 添加一个新的验证码邮件任务。*/
+    Mono<ServerResponse>
+    addVerifyCodeEmailTask(ServerRequest request);
+
+    /** 添加一个新的纯文本邮件任务。*/
+    Mono<ServerResponse>
+    addTextEmailTask(ServerRequest request);
+
+    /** 添加一个新的携带附件的邮件任务。*/
+    Mono<ServerResponse>
+    addAttechmentEmailTask(ServerRequest request);
+
+    /** 添加一个新的邮件任务。（通用添加操作）*/
+    Mono<ServerResponse>
+    addEmailTask(ServerRequest request);
+}

--- a/src/main/java/com/example/jesse/item_market/email_send_task/service/impl/EmailTaskServiceImpl.java
+++ b/src/main/java/com/example/jesse/item_market/email_send_task/service/impl/EmailTaskServiceImpl.java
@@ -1,0 +1,320 @@
+package com.example.jesse.item_market.email_send_task.service.impl;
+
+import com.example.jesse.item_market.email.dto.EmailContent;
+import com.example.jesse.item_market.email.utils.VerifyCodeGenerator;
+import com.example.jesse.item_market.email_send_task.EmailSenderTask;
+import com.example.jesse.item_market.email_send_task.dto.AttachmentMailArgsDTO;
+import com.example.jesse.item_market.email_send_task.dto.EmailContentDTO;
+import com.example.jesse.item_market.email_send_task.dto.TextMailArgsDTO;
+import com.example.jesse.item_market.email_send_task.dto.VerifyMailArgsDTO;
+import com.example.jesse.item_market.email_send_task.impl.TaskPriority;
+import com.example.jesse.item_market.email_send_task.service.EmailTaskService;
+import com.example.jesse.item_market.response.ResponseBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+import static com.example.jesse.item_market.response.URLParamPrase.praseNumberRequestParam;
+import static com.example.jesse.item_market.response.URLParamPrase.praseRequestParam;
+import static java.lang.String.format;
+
+/** 邮件任务服务实现。*/
+@Slf4j
+@Service
+public class EmailTaskServiceImpl implements EmailTaskService
+{
+    @Autowired
+    private EmailSenderTask emailSenderTask;
+
+    @Autowired
+    private ResponseBuilder responseBuilder;
+
+    /** 启动 项目邮件任务。*/
+    @Override
+    public Mono<ServerResponse>
+    startEmailTask(ServerRequest request)
+    {
+        if (this.emailSenderTask.isTaskStarted())
+        {
+            return
+            this.responseBuilder
+                .BAD_REQUEST("Email task has been started!", null);
+        }
+
+        Mono.when(
+            this.emailSenderTask
+                .startPollDelayZset(),
+            this.emailSenderTask
+                .startExcuteEmailSenderTask())
+        .subscribe();
+
+        return
+        this.responseBuilder
+            .OK(
+                null, "Email task started!",
+                null, null
+            );
+    }
+
+    /** 停止 项目邮件任务。*/
+    @Override
+    public Mono<ServerResponse>
+    stopEmailTask(ServerRequest request)
+    {
+        return
+        Mono.fromRunnable(() -> {
+            this.emailSenderTask.stopPollDelayZset();
+            this.emailSenderTask.stopExcuteEmailSenderTask();
+        })
+        .then(
+            this.responseBuilder
+                .OK(
+                    null, "Email task stop!",
+                    null, null))
+        .onErrorResume((excption) ->
+            this.responseBuilder
+                .INTERNAL_SERVER_ERROR(
+                    format(
+                        "Stop email task failed! Caused by: %s", excption.getMessage()),
+                    excption
+                )
+            );
+    }
+
+    /** 停止 延迟邮件任务有序集合的轮询。*/
+    @Override
+    public Mono<ServerResponse>
+    stopPollDelayZset(ServerRequest request)
+    {
+        return
+        Mono.fromRunnable(() ->
+            this.emailSenderTask
+                .stopPollDelayZset())
+            .then(
+                this.responseBuilder
+                    .OK(
+                        null, "Stop poll delay zset complete!",
+                        null, null
+                    ))
+            .onErrorResume((excption) ->
+                this.responseBuilder
+                    .INTERNAL_SERVER_ERROR(
+                        format(
+                            "Stop poll delay zset failed! Caused by: %s",
+                            excption.getMessage()
+                        ), excption
+                    )
+            );
+    }
+
+    /** 停止 优先有序集合的邮件发送任务。*/
+    @Override
+    public Mono<ServerResponse>
+    stopExecuteEmailSenderTask(ServerRequest request)
+    {
+        return
+        Mono.fromRunnable(() ->
+                this.emailSenderTask
+                    .stopPollDelayZset())
+            .then(
+                this.responseBuilder
+                    .OK(
+                        null, "Stop excute email sender complete!",
+                        null, null
+                    ))
+            .onErrorResume((excption) ->
+                this.responseBuilder
+                    .INTERNAL_SERVER_ERROR(
+                        format(
+                            "Stop excute email sender failed! Caused by: %s",
+                            excption.getMessage()
+                        ), excption
+                    )
+                );
+    }
+
+    /** 添加一个新的验证码邮件任务。*/
+    @Override
+    public Mono<ServerResponse>
+    addVerifyCodeEmailTask(@NotNull ServerRequest request)
+    {
+        return
+        Mono.zip(
+            request.bodyToMono(VerifyMailArgsDTO.class),
+            VerifyCodeGenerator.generateVerifyCode(6))
+        .flatMap((mailParts) -> {
+            final VerifyMailArgsDTO verifyEmailArgs = mailParts.getT1();
+            final String            verifyCode      = mailParts.getT2();
+
+            return
+            EmailContent.fromVarify(
+                verifyEmailArgs.getUserName(),
+                verifyEmailArgs.getUserEmail(),
+                verifyCode,
+                Duration.ofMinutes(verifyEmailArgs.getExpired())
+            );
+        })
+        .flatMap((mailContent) ->
+            /* 验证码邮件 优先级：高，延迟发送：无 */
+            this.emailSenderTask
+                .addEmailTask(mailContent, TaskPriority.HIGH, Duration.ZERO)
+        )
+        .flatMap((taskId) ->
+            this.responseBuilder
+                .OK(
+                    null,
+                    format("Add verify code mail task complete! Task ID: %s", taskId),
+                    null, null
+                )
+        )
+        .onErrorResume((exception) ->
+            this.responseBuilder
+                .INTERNAL_SERVER_ERROR(
+                    format(
+                        "Add new verify code email task failed! Cause by: %s",
+                        exception.getMessage()
+                    ), exception
+                )
+        );
+    }
+
+    /** 添加一个新的纯文本邮件任务。*/
+    @Override
+    public Mono<ServerResponse>
+    addTextEmailTask(@NotNull ServerRequest request)
+    {
+        return
+        Mono.zip(
+            request.bodyToMono(TextMailArgsDTO.class),
+            praseRequestParam(request, "priority")
+                .map((p) -> TaskPriority.valueOf(p.toUpperCase())),
+            praseNumberRequestParam(request, "delay", Long::parseLong)
+                .map(Duration::ofSeconds))
+        .flatMap((mailParams) -> {
+            final TextMailArgsDTO textMailArgs = mailParams.getT1();
+            final TaskPriority    priority     = mailParams.getT2();
+            final Duration        taskDelay    = mailParams.getT3();
+
+            return
+            EmailContent.fromJustText(
+                textMailArgs.getUserEmail(),
+                textMailArgs.getSubject(),
+                textMailArgs.getMessage())
+            .flatMap((mailContent) ->
+                this.emailSenderTask
+                    .addEmailTask(mailContent, priority, taskDelay)
+            );
+        })
+        .flatMap((taskId) ->
+            this.responseBuilder
+                .OK(
+                    null,
+                    format("Add text mail task complete! Task ID: %s", taskId),
+                    null, null
+                )
+        )
+        .onErrorResume((exception) ->
+            this.responseBuilder
+                .INTERNAL_SERVER_ERROR(
+                    format(
+                        "Add new text email task failed! Cause by: %s",
+                        exception.getMessage()
+                    ), exception
+                )
+        );
+    }
+
+    /** 添加一个新的携带附件的邮件任务。*/
+    @Override
+    public Mono<ServerResponse>
+    addAttechmentEmailTask(@NotNull ServerRequest request)
+    {
+        return
+        Mono.zip(
+            request.bodyToMono(AttachmentMailArgsDTO.class),
+            praseRequestParam(request, "priority")
+                .map((p) -> TaskPriority.valueOf(p.toUpperCase())),
+            praseNumberRequestParam(request, "delay", Long::parseLong)
+                .map(Duration::ofSeconds))
+        .flatMap((mailParams) -> {
+            final AttachmentMailArgsDTO
+                attachmentMainArgs      = mailParams.getT1();
+            final TaskPriority priority = mailParams.getT2();
+            final Duration taskDelay    = mailParams.getT3();
+
+            return
+            EmailContent.formWithAttachment(
+                attachmentMainArgs.getUserName(),
+                attachmentMainArgs.getUserEmail(),
+                attachmentMainArgs.getSubject(),
+                attachmentMainArgs.getMessage(),
+                attachmentMainArgs.getAttachmentName(),
+                attachmentMainArgs.getAttachmentData())
+            .flatMap((emailContent) ->
+                this.emailSenderTask
+                    .addEmailTask(emailContent, priority, taskDelay));
+        })
+        .flatMap((taskId) ->
+            this.responseBuilder
+                .OK(
+                    null,
+                    format("Add text mail task complete! Task ID: %s", taskId),
+                    null, null
+                )
+        )
+        .onErrorResume((exception) ->
+            this.responseBuilder
+                .INTERNAL_SERVER_ERROR(
+                    format(
+                        "Add new text email task failed! Cause by: %s",
+                        exception.getMessage()
+                    ), exception
+                )
+        );
+    }
+
+    /** 添加一个新的邮件任务。（通用添加操作）*/
+    @Override
+    public Mono<ServerResponse>
+    addEmailTask(@NotNull ServerRequest request)
+    {
+        return
+        Mono.zip(
+            request.bodyToMono(EmailContentDTO.class),
+            praseRequestParam(request, "priority")
+                .map((p) -> TaskPriority.valueOf(p.toUpperCase())),
+            praseNumberRequestParam(request, "delay", Long::parseLong)
+                .map(Duration::ofSeconds))
+        .flatMap((requestData) -> {
+            final EmailContent emailContent = requestData.getT1().toEmailContent();
+            final TaskPriority taskPriority = requestData.getT2();
+            final Duration     delay        = requestData.getT3();
+
+            return
+            this.emailSenderTask
+                .addEmailTask(emailContent, taskPriority, delay);
+        })
+        .flatMap((taskId) ->
+            this.responseBuilder
+                .OK(
+                    null,
+                    format("Create email task complete! Task ID: %s", taskId),
+                    null, null
+                ))
+        .onErrorResume((exception) ->
+            this.responseBuilder
+                .INTERNAL_SERVER_ERROR(
+                    format(
+                        "Add new email task failed! Cause by: %s",
+                        exception.getMessage()
+                    ), exception
+                )
+        );
+    }
+}

--- a/src/main/java/com/example/jesse/item_market/response/Link.java
+++ b/src/main/java/com/example/jesse/item_market/response/Link.java
@@ -1,0 +1,21 @@
+package com.example.jesse.item_market.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+
+/**
+ * 这个类用来表示 HATEOAS 元数据中的某一条链接。
+ */
+@Data
+@Slf4j
+@NoArgsConstructor
+@AllArgsConstructor
+public class Link
+{
+    private String      rel;
+    private String      href;
+    private HttpMethod  method;
+}

--- a/src/main/java/com/example/jesse/item_market/response/ResponseBuilder.java
+++ b/src/main/java/com/example/jesse/item_market/response/ResponseBuilder.java
@@ -1,0 +1,536 @@
+package com.example.jesse.item_market.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.*;
+import java.util.function.Consumer;
+
+/** HTTP 通用响应构建器。*/
+@Slf4j
+@Component
+@Accessors(chain = true)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final public class ResponseBuilder
+{
+    /**
+     * 响应体静态模板类。
+     *
+     * @param <T> 响应体数据类型
+     */
+    @Data
+    @NoArgsConstructor
+    public static class APIResponse<T>
+    {
+        /** 响应时间戳（默认是构造本响应体那一刻的时间）*/
+        private final long timestamp = Instant.now().toEpochMilli();
+
+        /** 响应码 */
+        private HttpStatus status;
+
+        /** 响应消息 */
+        private String message;
+
+        /**
+         * 响应数据，
+         * 使用 @JsonInclude(JsonInclude.Include.NON_NULL) 注解，</br>
+         * 在 data == null 的情况下，这个字段就不会序列化到 JSON 中去。
+         */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private T data;
+
+        /**
+         * 响应元数据，
+         * 使用 @JsonInclude(JsonInclude.Include.NON_EMPTY) 注解，</br>
+         * metadata 为 null、ImmutableCollections.EMPTY_MAP、
+         * 或者其他没有任何元素的空 Map 时，这个字段不会被序列化到 JSON 中去。
+         */
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private Map<String, Object> metadata = new HashMap<>();
+
+        /**
+         * 检查当前响应体中有没有键 _links 映射的 HATEOAS 链接表，
+         * 有转换后返回，没有则创建一个后返回。
+         */
+        private Map<String, Object> getOrCreateLinksMap()
+        {
+            Object linksObj = this.getMetadata().get("_links");
+
+            if (linksObj instanceof Map)
+            {
+                @SuppressWarnings(value = "unchecked")
+                Map<String, Object> linksMap = (Map<String, Object>) linksObj;
+
+                return linksMap;
+            }
+            else
+            {
+                Map<String, Object> linksMap = new HashMap<>();
+                this.getMetadata().put("_links", linksMap);
+
+                return linksMap;
+            }
+        }
+
+        /**
+         * 创建单个 HATEOAS 链接表。
+         *
+         * @param href   链接字符串
+         * @param method 请求方法
+         */
+        private @NotNull Map<String, String>
+        createLinkObject(String href, String method)
+        {
+            Map<String, String> link = new HashMap<>();
+
+            link.put("href", href);
+            link.put("method", method);
+
+            return link;
+        }
+
+        /** 响应体的构造方法。*/
+        public APIResponse(@NotNull HttpStatus status) {
+            this.status   = status;
+            this.message  = status.getReasonPhrase();
+        }
+
+        /**
+         * 在响应体中添加分页元数据。
+         *
+         * @param page        第几页？
+         * @param size        一页几条数据？
+         * @param totalItems  总共几条数据？
+         *
+         * @return 添加完分页元数据的响应体
+         */
+        public APIResponse<T>
+        withPagination(int page, int size, long totalItems)
+        {
+            Map<String, Object> pagination = new HashMap<>();
+
+            pagination.put("page", page);
+            pagination.put("size", size);
+            pagination.put("totalItem", totalItems);
+
+            this.getMetadata().put("pagination", pagination);
+
+            return this;
+        }
+
+        /**
+         * 在响应体元数据中添加 HATEOAS 元数据。
+         * <p>
+         *      HATEOAS 全称为 Hypermedia as the Engine of Application State，
+         *      作为 REST 架构的核心约束之一，它是一种可以让响应体能够自我描述的理念
+         *     （即响应体不仅包括了相关数据，还包括了相关操作的链接）。
+         * </p>
+         * <p>假设没有添加 HATEOAS 的响应体是这样的：</p>
+         * <pre><code>
+         * {
+         *     "message": "Query score record id = 300 success!",
+         *     "data": {
+         *         "scoreId": 300,
+         *         "userId": 1,
+         *         "userName": "Jesse",
+         *         "submitDate": [2025, 2, 3, 10, 22, 6],
+         *         "correctCount": 10,
+         *         "errorCount": 26,
+         *         "noAnswerCount": 38
+         *     },
+         *     "statues": "OK",
+         *     "time_STAMP": 1750942236538
+         * }
+         * </code></pre>
+         *
+         * <p>
+         *     那么添加了 HATEOAS 元数据的响应体可能是这样的
+         *     （多出了相关操作的链接，前端可以更方便地执行相关操作，不需要再手动的拼接 URL）：
+         * </p>
+         * <pre><code>
+         * {
+         *     "message": "Query score record id = 300 success!",
+         *     "data": {
+         *         "scoreId": 300,
+         *         "userId": 1,
+         *         "userName": "Jesse",
+         *         "submitDate": [2025, 2, 3, 10, 22, 6],
+         *         "correctCount": 10,
+         *         "errorCount": 26,
+         *         "noAnswerCount": 38
+         *     },
+         *     "metadata": {
+         *          "_links": {
+         *              "self": {
+         *                  "href": "/api/score_record?id=300",
+         *                  "method": "GET"
+         *              },
+         *              "next": {
+         *                  "href": "/api/score_record?id=301",
+         *                  "method": "GET"
+         *              },
+         *              "previous" : {
+         *                  "href": "/api/score_record?id=299",
+         *                  "method": "GET"
+         *              },
+         *              "update" : {
+         *                  "href" : "/api/score_record?id=300",
+         *                  "method" : "PUT"
+         *              },
+         *              "related": [
+         *              {
+         *                  "href": "/api/score_record/rank",
+         *                  "method": "GET"
+         *              },
+         *              {
+         *                  ....
+         *              }
+         *          ]
+         *     }
+         *     "statues": "OK",
+         *     "time_STAMP": 1750942236538
+         * }
+         * </code></pre>
+         *
+         * <p>
+         *     HATEOAS 元数据添加规则：
+         *     <ol>
+         *         <li>首次添加不存在的链接   -> 存储为单对象</li>
+         *         <li>再次添加简述相同的链接 -> 转换为数组后再存储</li>
+         *         <li>后续添加简述相同的链接 -> 追加到数组</li>
+         *     </ol>
+         * </p>
+         *
+         * @param rel    链接简述
+         * @param href   链接字符串
+         * @param method 请求方法
+         *
+         * @return 添加完 HATEOAS 元数据的响应体
+         */
+        public APIResponse<T>
+        withLink(String rel, String href, HttpMethod method)
+        {
+            Map<String, Object> linksMap = this.getOrCreateLinksMap();
+
+            Object existLinkingMap = linksMap.get(rel);
+
+            switch (existLinkingMap)
+            {
+                case null -> linksMap.put(rel, this.createLinkObject(href, method.name()));
+
+                case Map<?, ?> ignored ->
+                {
+                    List<Object> linksList = new ArrayList<>();
+
+                    linksList.add(existLinkingMap);
+                    linksList.add(this.createLinkObject(href, method.name()));
+
+                    linksMap.put(rel, linksList);
+                }
+                case List<?> ignored ->
+                {
+                    @SuppressWarnings(value = "unchecked")
+                    List<Object> linksList = (List<Object>) existLinkingMap;
+
+                    linksList.add(this.createLinkObject(href, method.name()));
+                }
+                default -> {}
+            }
+
+            return this;
+        }
+
+        /**
+         * 在响应体元数据中添加 HATEOAS 元数据（默认使用 GET 方法）。
+         *
+         * @param rel    链接简述
+         * @param href   链接字符串
+         */
+        public APIResponse<T>
+        withLink(String rel, String href) {
+            return this.withLink(rel, href, HttpMethod.GET);
+        }
+    }
+
+    /**
+     * 响应体构建器。
+     *
+     * @param <T> 响应体数据类型
+     *
+     * @param status        响应码
+     * @param data          响应体
+     * @param customMessage 响应消息
+     * @param hateOASLink   HATEOAS 元数据集合
+     *
+     * @return 构造好地响应体
+     */
+    private <T> APIResponse<T> produceBody(
+        HttpStatus status, T data,
+        String customMessage,
+        Set<Link> hateOASLink
+    )
+    {
+        APIResponse<T> response = new APIResponse<>(status);
+        response.setData(data);
+
+        if (customMessage != null) {
+            response.setMessage(customMessage);
+        }
+
+        if (hateOASLink != null)
+        {
+            for (Link link : hateOASLink)
+            {
+                response.withLink(
+                    link.getRel(),
+                    link.getHref(), link.getMethod()
+                );
+            }
+        }
+
+        return response;
+    }
+
+    /**
+     * 基础响应的构建其一。
+     *
+     * <p>用例如下所式：</p>
+     * <pre><code>
+     * ResponseBuilder builder;
+     * builder.build(
+     *     OK, data,
+     *     headers -> {
+     *         headers.add("X-RateLimit-Remaining", "100");
+     *         headers.setContentType(MediaType.APPLICATION_JSON);
+     *     }, hateOASLink
+     * );
+     * </code></pre>
+     *
+     * @param status            响应码
+     * @param body              响应体
+     * @param headersCustomizer 响应头消费者
+     * @param hateOASLink       HATEOAS 元数据集合
+     *
+     * @return 构造好地响应体 Mono
+     */
+    public @NotNull Mono<ServerResponse> build(
+        HttpStatus status, Object body, String customMessage,
+        Consumer<HttpHeaders> headersCustomizer,
+        Set<Link> hateOASLink
+    )
+    {
+        return ServerResponse.status(status)
+            .headers(headersCustomizer)
+            .bodyValue(
+                this.produceBody(
+                    status, body,
+                    customMessage, hateOASLink
+                )
+            );
+    }
+
+    /**
+     * 基础响应的构建其二。
+     *
+     * @param <T> 响应数据类型
+     *
+     * @param headersCustomizer 响应头消费者
+     * @param response 响应体数据（外部构建）
+     *
+     * @return 构造好地响应体 Mono
+     */
+    public @NotNull <T> Mono<ServerResponse>
+    build(
+        Consumer<HttpHeaders>   headersCustomizer,
+        @NotNull APIResponse<T> response
+    )
+    {
+        return ServerResponse.status(response.getStatus())
+            .headers(headersCustomizer)
+            .bodyValue(response);
+    }
+
+    /**
+     * 创建 201 响应码构成的响应体，
+     * 多用于 POST 或 PUT 方法。
+     *
+     * <p>用例如下所式：</p>
+     * <pre><code>
+     * ResponseBuilder builder;
+     * builder.buildCreated(
+     *     URI.create("/api/query?id=114"),
+     *     newResource,
+     *     headers -> {
+     *         headers.add("X-RateLimit-Remaining", "100");
+     *         headers.add("X-Custom-Header", "value");
+     *         headers.setContentType(MediaType.APPLICATION_JSON);
+     *     }
+     * );
+     * </code></pre>
+     *
+     * @param location          新创建的资源的 URI
+     * @param body              响应体
+     * @param headersCustomizer 响应头消费者
+     *
+     * @return 构造好地响应体 Mono
+     */
+    public @NotNull Mono<ServerResponse>
+    buildCreated(
+        URI location, Object body, String customMessage,
+        Consumer<HttpHeaders> headersCustomizer,
+        Set<Link> hateOASLink
+    )
+    {
+        Consumer<HttpHeaders> headersCombined
+            = (headers) -> {
+            headers.setLocation(location);
+
+            if (headersCustomizer != null) {
+                headersCustomizer.accept(headers);
+            }
+        };
+
+        return ServerResponse.status(HttpStatus.CREATED)
+            .headers(headersCombined)
+            .bodyValue(
+                this.produceBody(
+                    HttpStatus.CREATED, body,
+                    customMessage, hateOASLink
+                )
+            );
+    }
+
+    /**
+     * 错误响应的构建。
+     *
+     * <p>用例如下所式：</p>
+     * <pre><code>
+     * ResponseBuilder builder;
+     * builder.buildError(
+     *     HttpStatus.NOT_FOUND, message,
+     *     new RuntimeException("Resource NOT FOUND!"),
+     *     headers ->
+     *         headers.setContentType(MediaType.APPLICATION_JSON)
+     * );
+     * </code></pre>
+     *
+     * @param status            响应码
+     * @param message           错误消息
+     * @param exception         异常接口
+     * @param headersCustomizer 响应头消费者
+     *
+     * @return 构造好地响应体 Mono
+     */
+    public @NotNull Mono<ServerResponse>
+    buildError(
+        HttpStatus status, String message,
+        Throwable exception,
+        Consumer<HttpHeaders> headersCustomizer
+    )
+    {
+        log.error("API ERROR: {}.", message, exception);
+
+        APIResponse<?> response
+            = this.produceBody(
+            status, null, message, null
+        );
+        response.getMetadata().put("errorCode", "ERR_" + status.value());
+
+        return ServerResponse.status(status)
+            .headers(headersCustomizer)
+            .bodyValue(response);
+    }
+
+    /** OK 响应的预设构建。*/
+    public @NotNull Mono<ServerResponse>
+    OK(
+        Object data, String customMessage,
+        Consumer<HttpHeaders> headerCustomizer,
+        Set<Link> hateOASLink
+    )
+    {
+        return this.build(
+            HttpStatus.OK, data, customMessage,
+            headers -> {
+                headers.setContentType(MediaType.APPLICATION_JSON);
+                if (headerCustomizer != null) {
+                    headerCustomizer.accept(headers);
+                }
+            }, hateOASLink
+        );
+    }
+
+    /** CREATED 响应的预设构建。*/
+    public @NotNull Mono<ServerResponse>
+    CREATED(
+        URI location, String customMessage,
+        Object body, Set<Link> hateOASLink
+    )
+    {
+        return this.buildCreated(
+            location, body, customMessage,
+            (headers) -> {
+                /*
+                 * X-RateLimit-Remaining 用于提示客户端，
+                 * 还可以发起多少个请求，如果客户端的请求数超过这个值就会被拦截，
+                 * 并返回 429 Too Many Requests 状态码。
+                 */
+                headers.add("X-RateLimit-Remaining", "100");
+                headers.add("X-Custom-Header", "value");
+                headers.setContentType(MediaType.APPLICATION_JSON);
+            }, hateOASLink
+        );
+    }
+
+    /** BAD REQUEST 响应的预设构建。*/
+    public @NotNull Mono<ServerResponse>
+    BAD_REQUEST(String message, Throwable exception)
+    {
+        return this.buildError(
+            HttpStatus.BAD_REQUEST, message,
+            exception,
+            headers ->
+                headers.setContentType(MediaType.APPLICATION_JSON)
+        );
+    }
+
+    /** NOT FOUND 响应的预设构建。*/
+    public @NotNull Mono<ServerResponse>
+    NOT_FOUND(String message, Throwable exception)
+    {
+        return this.buildError(
+            HttpStatus.NOT_FOUND, message,
+            exception,
+            headers ->
+                headers.setContentType(MediaType.APPLICATION_JSON)
+        );
+    }
+
+    /** INTERNAL_SERVER_ERROR 响应的预设构建。*/
+    public @NotNull Mono<ServerResponse>
+    INTERNAL_SERVER_ERROR(String message, Throwable exception)
+    {
+        return this.buildError(
+            HttpStatus.INTERNAL_SERVER_ERROR, message,
+            exception,
+            headers ->
+                headers.setContentType(MediaType.APPLICATION_JSON)
+        );
+    }
+
+    /* 后续的可以继续补充响应的预设构建。*/
+}

--- a/src/main/java/com/example/jesse/item_market/response/URLParamPrase.java
+++ b/src/main/java/com/example/jesse/item_market/response/URLParamPrase.java
@@ -1,0 +1,107 @@
+package com.example.jesse.item_market.response;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+import static java.lang.String.format;
+
+/** URL 参数解析工具类。（响应式版本）*/
+@NoArgsConstructor(access  = AccessLevel.PRIVATE)
+final public class URLParamPrase
+{
+    /**
+     * <p>从 HTTP 请求的 URI 中查询指定的参数。</p>
+     *
+     * <p>
+     *     比如 URL：<code>/api/query?name=perter</code>
+     *     调用本方法 <code>getRequestParam(request, "name")</code>，返回字符串 perter。
+     * </p>
+     *
+     * @param request    从前端传来的 HTTP 请求实例
+     * @param paramName  参数名
+     *
+     * @throws IllegalArgumentException
+     *         当 paramName 在 URI 中查询不到时抛出。
+     */
+    public static @NotNull Mono<String>
+    praseRequestParam(final ServerRequest request, String paramName)
+    {
+        return Mono.fromCallable(
+            () -> {
+                if (request.queryParam(paramName).isEmpty())
+                {
+                    throw new IllegalArgumentException(
+                        format(
+                            "Parameter name [%s] not exist in request!",
+                            paramName
+                        )
+                    );
+                }
+
+                return
+                request.queryParam(paramName).get();
+            }
+        );
+    }
+
+    /**
+     * <p>从 HTTP 请求的 URL 中查询指定的参数，将其转化成数字类型使用。</p>
+     *
+     * <p>
+     *     比如 URL：<code>/api/query?id=114</code>
+     *     调用本方法
+     *     <code>
+     *         getRequestParam(request, "id", Integer::parseInt)
+     *     </code>
+     *     ，返回整数 114。
+     * </p>
+     *
+     * @param <T> 由于本方法是 T 的生成者，所以需要规定 T 的上界，
+     *            即 T 可以说由 Number 派生下来的所以类型
+     *
+     * @param request    从前端传来的 HTTP 请求实例
+     * @param paramName  参数名
+     * @param converter  调用哪个转换方法？
+     *
+     * @return 从 URL 中解析下来的参数
+     *
+     * @throws IllegalArgumentException
+     *         1. 当 paramName 在 URI 中查询不到时抛出。</br>
+     *         2. 当 phraseVal 的值小于 0 时抛出。
+     *
+     * @throws NumberFormatException
+     *         当 paramName 转化成数字失败时抛出。
+     */
+    public static <T extends Number> @NotNull Mono<T>
+    praseNumberRequestParam(
+        final ServerRequest request, String paramName,
+        Function<String, T> converter
+
+    )
+    {
+        return praseRequestParam(request, paramName)
+            .map((param) -> {
+                T number = converter.apply(param);
+
+                if (number.doubleValue() < 0)
+                {
+                    throw new IllegalArgumentException(
+                        format("Parameter: [%s] not less than 0!", paramName)
+                    );
+                }
+
+                return number;
+            })
+            .onErrorMap(NumberFormatException.class,
+                exception ->
+                    new IllegalArgumentException("Invalid number format for parameter: " + paramName))
+            .onErrorMap(IllegalArgumentException.class,
+                exception -> exception)
+            .onErrorResume(Mono::error);
+    }
+}


### PR DESCRIPTION
## 1. 原邮件发送模块的缺陷

```java
public class EmailContent
{
    /** 发给谁 (如 PerterGriffen@gmail.com) */
    private String to;

    /** 邮箱主题 */
    private String subject;

    /** 邮件正文 */
    private String textBody;

    /** 附件路径（可以为 null 表示没有附件）*/
    @Nullable
    private String attachmentPath;

   /** ... */
}
```

原来邮件内容的 DTO 中，使用邮件路径表示附件，这在本地执行似乎没问题，但是一旦把这个 DTO 包装成任务发送到远程，就很容易遭到路径攻击，远程服务器也因为找不到指定文件而抛出异常，因此我对该 DTO 做出如下改进：

```java
public class EmailContent
{
    /** 发给谁 (如 PerterGriffen@gmail.com) */
    private String to;

    /** 邮件主题 */
    private String subject;

    /** 邮件正文 */
    private String textBody;

    /** 附件文件名（可以为 null 表示没有附件）*/
    @Nullable
    private String attachmentName;

    /** 附件数据（可以为 null 表示没有附件）*/
    @Nullable
    private byte[] attachmentData;

    /* ... */
}
```

使用 附件文件名 和 附件数据 来表示一个附件（附件的大小有限制，所以这样的操作是可行的），并增加附件 Mime Type 获取器工具类，详见：

[MimeTypeGetter](https://github.com/JesseZ332623/item-market/blob/email_fix/src/main/java/com/example/jesse/item_market/email/utils/MimeTypeGetter.java)


重构后的响应式邮件发送器实现详见：

[Reactive EmailSender](https://github.com/JesseZ332623/item-market/blob/email_fix/src/main/java/com/example/jesse/item_market/email/service/impl/EmailSender.java)

## 2. 邮件任务发送器服务模块编写

模块详见：
[Email Send Task](https://github.com/JesseZ332623/item-market/tree/email_fix/src/main/java/com/example/jesse/item_market/email_send_task)

核心接口如下所示：

```java
/** 邮件任务服务接口。*/
public interface EmailTaskService
{
    /** 启动 项目邮件任务。*/
    Mono<ServerResponse>
    startEmailTask(ServerRequest request);

    /** 停止 项目邮件任务。*/
    Mono<ServerResponse>
    stopEmailTask(ServerRequest request);

    /** 停止 延迟邮件任务有序集合的轮询。*/
    Mono<ServerResponse>
    stopPollDelayZset(ServerRequest request);

    /** 停止 优先有序集合的邮件发送任务。*/
    Mono<ServerResponse>
    stopExecuteEmailSenderTask(ServerRequest request);

    /** 添加一个新的验证码邮件任务。*/
    Mono<ServerResponse>
    addVerifyCodeEmailTask(ServerRequest request);

    /** 添加一个新的纯文本邮件任务。*/
    Mono<ServerResponse>
    addTextEmailTask(ServerRequest request);

    /** 添加一个新的携带附件的邮件任务。*/
    Mono<ServerResponse>
    addAttechmentEmailTask(ServerRequest request);

    /** 添加一个新的邮件任务。（通用添加操作）*/
    Mono<ServerResponse>
    addEmailTask(ServerRequest request);
}
```

主要是为前端页面开放控制邮件发送任务执行器的接口。
