### PR TITLE
用户服务相关问题修复

### DIFF
--- a/src/main/java/com/example/jesse/item_market/user/impl/UserRedisServiceImpl.java
+++ b/src/main/java/com/example/jesse/item_market/user/impl/UserRedisServiceImpl.java
@@ -606,6 +606,9 @@ public class UserRedisServiceImpl implements UserRedisService
                         {
                             case "SUCCESS" -> Mono.empty();
 
+                            case "WEAPON_NOT_FOUND" ->
+                                Mono.error(new NoSuchElementException());
+
                             case null, default ->
                                 Mono.error(
                                     new IllegalStateException(
@@ -657,7 +660,7 @@ public class UserRedisServiceImpl implements UserRedisService
                         {
                             case "USER_NOT_FOUND" ->
                                 Mono.error(
-                                    new IllegalArgumentException(
+                                    new NoSuchElementException(
                                         format("UUID: %s not exits!", uuid)
                                     )
                                 );

--- a/src/main/java/com/example/jesse/item_market/user/route/UserServiceRouteFunctionConfig.java
+++ b/src/main/java/com/example/jesse/item_market/user/route/UserServiceRouteFunctionConfig.java
@@ -24,19 +24,20 @@ public class UserServiceRouteFunctionConfig
         return
         RouterFunctions
             .route()
-            .GET(FIND_ALL_USER_UUID_URI,    this.userService::findAllUserUUID)
-            .GET(FIND_CONTACTS_BY_UUID_URI, this.userService::findContactListByUUID)
+            .GET(FIND_ALL_USER_UUID_URI,              this.userService::findAllUserUUID)
+            .GET(FIND_CONTACTS_BY_UUID_URI,           this.userService::findContactListByUUID)
             .GET(FIND_ALL_WEAPONS_FROM_INVENTORY_URI, this.userService::findAllWeaponsFromInventoryByUUID)
             .GET(FIND_ALL_WEAPONS_FROM_MARKET_URI,    this.userService::findAllWeaponsFromMarketByUUID)
-            .GET(FIND_USER_INFO_URI,    this.userService::findUserInfoByUUID)
-            .POST(CREATE_NEW_USER_URI,  this.userService::createNewUser)
-            .POST(ADD_NEW_CONTACT_URI,  this.userService::addNewContact)
-            .POST(ADD_WEAPON_TO_INVENTORY_URI, this.userService::addWeaponToInventory)
-            .POST(ADD_WEAPON_TO_MARKET_URI, this.userService::addWeaponToMarket)
-            .DELETE(DESTORY_WEAPON_FROM_INVENTORY, this.userService::destroyWeaponFromInventory)
-            .DELETE(REMOVE_CONTACT_URI, this.userService::removeContact)
-            .DELETE(REMOVE_WEAPON_FROM_MARKET, this.userService::removeWeaponFromMarket)
-            .DELETE(DELETE_USER, this.userService::deleteUser)
+            .GET(FIND_ALL_WEAPONIDS_FROM_MARKET_URI,  this.userService::findAllWeaponIdsFromMarketByUUID)
+            .GET(FIND_USER_INFO_URI,                  this.userService::findUserInfoByUUID)
+            .POST(CREATE_NEW_USER_URI,                this.userService::createNewUser)
+            .POST(ADD_NEW_CONTACT_URI,                this.userService::addNewContact)
+            .POST(ADD_WEAPON_TO_INVENTORY_URI,        this.userService::addWeaponToInventory)
+            .POST(ADD_WEAPON_TO_MARKET_URI,           this.userService::addWeaponToMarket)
+            .DELETE(DESTORY_WEAPON_FROM_INVENTORY,    this.userService::destroyWeaponFromInventory)
+            .DELETE(REMOVE_CONTACT_URI,               this.userService::removeContact)
+            .DELETE(REMOVE_WEAPON_FROM_MARKET,        this.userService::removeWeaponFromMarket)
+            .DELETE(DELETE_USER,                      this.userService::deleteUser)
             .build();
     }
 }

--- a/src/main/java/com/example/jesse/item_market/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/jesse/item_market/user/service/impl/UserServiceImpl.java
@@ -487,7 +487,7 @@ public class UserServiceImpl implements UserService
                     NoSuchElementException.class, 
                     (exception) ->
                         this.responseBuilder
-                            .BAD_REQUEST(exception.getMessage(), exception) 
+                            .NOT_FOUND(exception.getMessage(), exception)
                 )
                 .onErrorResume(
                     (exception) -> 
@@ -588,6 +588,16 @@ public class UserServiceImpl implements UserService
                                 weapon, uuid
                             ), null, null
                         ))
+                .onErrorResume(
+                    NoSuchElementException.class,
+                    (exception) ->
+                        this.responseBuilder.NOT_FOUND(
+                            String.format(
+                                "User %s unlist weapon: %s on market!",
+                                uuid, weapon.getItemName()
+                            ), exception
+                        )
+                )
                 .onErrorResume((exception) ->
                     this.responseBuilder
                         .INTERNAL_SERVER_ERROR(
@@ -622,6 +632,11 @@ public class UserServiceImpl implements UserService
                             null, null
                         ))
                     .onErrorResume(
+                        NoSuchElementException.class,
+                        (exception) ->
+                            this.responseBuilder
+                                .NOT_FOUND(exception.getMessage(), exception))
+                    .onErrorResume(
                         IllegalArgumentException.class, 
                         (exception) ->
                             this.responseBuilder
@@ -631,14 +646,14 @@ public class UserServiceImpl implements UserService
                             this.responseBuilder
                                 .INTERNAL_SERVER_ERROR(
                                     String.format("Faild to delete user: %s!", uuid), 
-                                    exception
-                        )
-                    ))
+                                    exception)
+                    )
+            )
             .onErrorResume(
-            IllegalArgumentException.class,
-            (exception) ->
-                this.responseBuilder
-                    .BAD_REQUEST(exception.getMessage(), exception)
+                IllegalArgumentException.class,
+                (exception) ->
+                    this.responseBuilder
+                        .BAD_REQUEST(exception.getMessage(), exception)
             );
     }
 }


### PR DESCRIPTION
## removeWeaponFromMarket.lua 脚本的问题

先看原脚本

```lua
--[[
    用户从市场上下架某个武器。

    KEYS:
        weaponPriceZsetKey      挂在市场上的武器价格键（market:weapon-market:weapon-price）
        sellerInventoryListKey  卖家包裹键（如：inventories:114935169325609268）
        userKey                 用户键（如：users:114934523722107784）

    ARGV:
        sellerUUID 卖家 UUID
        weaponName 武器名
]]
local userKey                = KEYS[1]
local weaponPriceZsetKey     = KEYS[2]
local sellerInventoryListKey = KEYS[3]

local sellerUUID  = ARGV[1]
local weaponName  = ARGV[2]

local timestamp = redis.call('TIME')[1]

-- 对于每一个 hash-key，查询买家 uuid 和 武器名，
-- 若买家 uuid 与传入的参数匹配，删除对应的整个哈希并添加审计信息
local cursor = "0"
repeat
    -- 分批次获取市场中的所有武器键
    local result
        = redis.call(
            'SCAN', cursor,
            'MATCH', 'market:weapon-market:weapons:*',
            'COUNT', 15,
            'TYPE', 'hash'
        )

    cursor = result[1]
    local weaponHashKeys = result[2]

    for i, weaponKey in ipairs(weaponHashKeys) do
        local fields 
            = redis.call(
                'HMGET', weaponKey, 
                "\"weapon-name\"", "\"seller\""
            )

        local scanWeaponName, scanSellerUUID
            = unpack(fields)

        local weaponId
            = string.match(weaponKey, ".*:(.*)")

        if
            scanWeaponName
            and scanSellerUUID
            and scanSellerUUID == sellerUUID
            and scanWeaponName == weaponName
        then
            redis.call('DEL', weaponKey)
            redis.call(
                'ZREM',
                "market:weapon-market:weapon-price",
                "\"" ..weaponId.. "\""
            )
            redis.call(
                'XADD',
                'market:log', '*',
                'event', 'WEAPON_OUTBOUND',
                'weaponId', "\"" ..weaponId.. "\"",
                'weaponName', weaponName,
                'seller', sellerUUID,
                'timestamp', timestamp
            )
        end
    end
until cursor == "0"

local userName = redis.call('HGET', userKey, "\"name\"")

-- 重新将武器放回对应用户的包裹中
redis.call('RPUSH', sellerInventoryListKey, weaponName)
redis.call(
    'XADD',
    'inventories:log', '*',
    'event', 'WEAPON_INBOUND',
    'uuid', sellerUUID,
    'user-name', userName,
    'weapon-name', weaponName,
    'amount', '1',
    'timestamp', timestamp
)

return '{"result": "SUCCESS"}'
```

可以看到，如果用户在没有在市场上上架武器的情况下执行下架操作，原脚本会 *让用户的包裹中凭空的多出一件武器*，虽然 “用户在没有在市场上上架武器的情况下执行下架” 的操作在前端页面无法执行，但是放着这个漏洞不管是不合理的，我做出如下修改：

```lua
--[[
    用户从市场上下架某个武器。

    KEYS:
        weaponPriceZsetKey      挂在市场上的武器价格键（market:weapon-market:weapon-price）
        sellerInventoryListKey  卖家包裹键（如：inventories:114935169325609268）
        userKey                 用户键（如：users:114934523722107784）

    ARGV:
        sellerUUID 卖家 UUID
        weaponName 武器名
]]
local userKey                = KEYS[1]
local sellerInventoryListKey = KEYS[3]

local sellerUUID  = ARGV[1]
local weaponName  = ARGV[2]

local timestamp = redis.call('TIME')[1]

local foundWeapon = false
local weaponId
local userName    = redis.call('HGET', userKey, "\"name\"")

-- 对于每一个 hash-key，查询买家 uuid 和 武器名，
-- 若买家 uuid 与传入的参数匹配，删除对应的整个哈希并添加审计信息
local cursor = "0"
repeat
    -- 分批次获取市场中的所有武器键
    local result
        = redis.call(
            'SCAN', cursor,
            'MATCH', 'market:weapon-market:weapons:*',
            'COUNT', 15,
            'TYPE', 'hash'
        )

    cursor = result[1]                  -- 获取当前游标值
    local weaponHashKeys = result[2]    -- 获取本页所有匹配的武器哈希键

    for i, weaponKey in ipairs(weaponHashKeys) do
        local fields 
            = redis.call(
                'HMGET', weaponKey, 
                "\"weapon-name\"", "\"seller\""
            )

        local scanWeaponName, scanSellerUUID
            = unpack(fields)

        if
            scanWeaponName
            and scanSellerUUID
            and scanSellerUUID == sellerUUID
            and scanWeaponName == weaponName
        then
            weaponId
                = string.match(weaponKey, ".*:(.*)")

            redis.call('DEL', weaponKey)
            redis.call(
                'ZREM',
                "market:weapon-market:weapon-price",
                "\"" ..weaponId.. "\""
            )
            redis.call(
                'XADD',
                'market:log', '*',
                'event', 'WEAPON_OUTBOUND',
                'weaponId', "\"" ..weaponId.. "\"",
                'weaponName', weaponName,
                'seller', sellerUUID,
                'timestamp', timestamp
            )

            foundWeapon = true  -- 只需要下架一件武器
            break
        end
    end

    -- 如果已经找到武器，提前结束SCAN
    if foundWeapon then
        break
    end
until cursor == "0"

-- 只有在找到并下架武器后才将其放回用户库存
if foundWeapon then

    -- 重新将武器放回对应用户的包裹中
    redis.call('RPUSH', sellerInventoryListKey, weaponName)
    redis.call(
            'XADD',
            'inventories:log', '*',
            'event', 'WEAPON_INBOUND',
            'uuid', sellerUUID,
            'user-name', userName,
            'weapon-name', weaponName,
            'amount', '1',
            'timestamp', timestamp
    )

    return '{"result": "SUCCESS"}'
else
    -- 如果用户在市场上没有上架指定武器，则返回错误消息
    return '{"result": "WEAPON_NOT_FOUND"}'
end
```

通过维护一个标志位 `foundWeapon` 确保市场和用户包裹的数据同步。

## 其他修复

都是一些小修小补，，不赘述了。。。